### PR TITLE
fix(ImageData): Force images to be opened in binary format

### DIFF
--- a/tools/classify.py
+++ b/tools/classify.py
@@ -129,7 +129,7 @@ def main(args):
     for image_path in FLAGS.image_path:
       if not os.path.exists(image_path):
         tf.logging.fatal('Input image does not exist %s', FLAGS.image_path[0])
-      img_data = tf.gfile.FastGFile(image_path).read()
+      img_data = tf.gfile.FastGFile(image_path, "rb").read()
       print(image_path)
       predictions_eval = np.squeeze(sess.run(predictions,
                                              {input_image: img_data}))


### PR DESCRIPTION
Fixes #29 

This change will tell python to open the images in binary format. Which prevents the UnicodeDecodeError on Windows.